### PR TITLE
Improvements to Gossip

### DIFF
--- a/client/logclient.go
+++ b/client/logclient.go
@@ -258,6 +258,7 @@ func (c *LogClient) GetEntryAndProof(ctx context.Context, index, treeSize uint64
 func (c *LogClient) PostGossipExchange(ctx context.Context, data ct.GossipExchangeRequest) (*ct.GossipExchangeResponse, error) {
 	req := ct.GossipExchangeRequest{
 		LogURL:       data.LogURL,
+		GossipOrigin: data.GossipOrigin,
 		STH:          data.STH,
 		IsConsistent: data.IsConsistent,
 		Proof:        data.Proof,

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -153,23 +153,15 @@ func DecodeGossipRequest(rw http.ResponseWriter, req *http.Request) (ct.GossipEx
 
 // EncodeGossipResponse encodes a GossipExchangeResponse
 /// TODO: Process the request instead of saving and responding
-func EncodeGossipResponse(rw http.ResponseWriter, gossipReq ct.GossipExchangeRequest) (ct.GossipExchangeResponse, error) {
-	gossipResp := ct.GossipExchangeResponse{
-		Acknowledged: true,
-		LogURL:       gossipReq.LogURL,
-		STH:          gossipReq.STH,
-	}
-
+func EncodeGossipResponse(rw http.ResponseWriter, gossipResp ct.GossipExchangeResponse) (ct.GossipExchangeResponse, error) {
 	rw.Header().Set("Content-Type", "application/json")
 	fmt.Printf("EncodeGossipResponse: %v\n", gossipResp)
 
 	encoder := json.NewEncoder(rw)
 	if err := encoder.Encode(gossipResp); err != nil {
-		fmt.Println("EncodeGossipResponse: Encoding Failed :(")
 		writeErrorResponse(&rw, http.StatusInternalServerError, fmt.Sprintf("Couldn't encode gossip response to return: %v", err))
 		return ct.GossipExchangeResponse{}, fmt.Errorf("Couldn't encode gossip response to return: %v", err)
 	}
-	fmt.Println("EncodeGossipResponse: Encoding Succeeded :)")
 
 	return gossipResp, nil
 }

--- a/gossip/minimal/configpb/config.pb.go
+++ b/gossip/minimal/configpb/config.pb.go
@@ -23,6 +23,8 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
+var gossipListenAddr string = ":6966"
+
 // LogConfig describes the configuration options for a source Log,
 // whose STH values are tracked/monitored.
 type LogConfig struct {
@@ -232,10 +234,13 @@ type GossipConfig struct {
 	BufferSize int32 `protobuf:"varint,5,opt,name=buffer_size,json=bufferSize,proto3" json:"buffer_size,omitempty"`
 	// The monitors with whom we will gossip
 	Monitor []*MonitorConfig `protobuf:"bytes,6,rep,name=monitor,json=monitor,proto3" json:"monitor,omitempty"`
+	// GossiperIdentifier is a unique identifier/prefix for a monitor
+	// it is used as a description of gossip origin in exchanged gossip information
+	GossiperIdentifier 	 string		`protobuf:"bytes,7,req,name=gossiper_identifier,proto3" json:"gossiper_identifier,omitempty"`
+	// the RPC endpoint to connect to Trillian
+	RPCEndpoint          string   `protobuf:"bytes,8,req,name=rpc_endpoint,proto3" json:"rpc_endpoint,omitempty"`
 	// The Address:Port on which Gossip Exchanges will happen
-	GossipListenAddr string `protobuf:"bytes,7,opt,name=gossip_listen_addr,proto3" json:"gossip_listen_addr,omitempty"`
-	// the RPC endpoint for Trillian
-	RPCEndpoint          string   `protobuf:"bytes,8,opt,name=rpc_endpoint,proto3" json:"rpc_endpoint,omitempty"`
+	GossipListenAddr string `protobuf:"bytes,9,opt,name=gossip_listen_addr,proto3" json:"gossip_listen_addr,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -265,20 +270,6 @@ func (m *GossipConfig) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_GossipConfig proto.InternalMessageInfo
-
-func (m *GossipConfig) GetGossipListenAddr() string {
-	if m != nil {
-		return m.GossipListenAddr
-	}
-	return ""
-}
-
-func (m *GossipConfig) GetRpcEndpoint() string {
-	if m != nil {
-		return m.RPCEndpoint
-	}
-	return ""
-}
 
 func (m *GossipConfig) GetSourceLog() []*LogConfig {
 	if m != nil {
@@ -313,6 +304,34 @@ func (m *GossipConfig) GetBufferSize() int32 {
 		return m.BufferSize
 	}
 	return 0
+}
+
+func (m *GossipConfig) GetMonitor() []*MonitorConfig {
+	if m != nil {
+		return m.Monitor
+	}
+	return nil
+}
+
+func (m *GossipConfig) GetGossiperIdentifier() string {
+	if m != nil {
+		return m.GossiperIdentifier
+	}
+	return ""
+}
+
+func (m *GossipConfig) GetGossipListenAddr() string {
+	if m != nil {
+		return m.GossipListenAddr
+	}
+	return gossipListenAddr
+}
+
+func (m *GossipConfig) GetRPCEndpoint() string {
+	if m != nil {
+		return m.RPCEndpoint
+	}
+	return ""
 }
 
 // GoshawkConfig describes the configuration of a gossiper.

--- a/gossip/minimal/configpb/config.pb.go
+++ b/gossip/minimal/configpb/config.pb.go
@@ -236,11 +236,11 @@ type GossipConfig struct {
 	Monitor []*MonitorConfig `protobuf:"bytes,6,rep,name=monitor,json=monitor,proto3" json:"monitor,omitempty"`
 	// GossiperIdentifier is a unique identifier/prefix for a monitor
 	// it is used as a description of gossip origin in exchanged gossip information
-	GossiperIdentifier 	 string		`protobuf:"bytes,7,opt,name=gossiper_identifier,proto3" json:"gossiper_identifier,omitempty"`
+	GossiperIdentifier string `protobuf:"bytes,7,opt,name=gossiper_identifier,proto3" json:"gossiper_identifier,omitempty"`
 	// the RPC endpoint to connect to Trillian
-	RPCEndpoint          string   `protobuf:"bytes,8,opt,name=rpc_endpoint,proto3" json:"rpc_endpoint,omitempty"`
+	RPCEndpoint string `protobuf:"bytes,8,opt,name=rpc_endpoint,proto3" json:"rpc_endpoint,omitempty"`
 	// The Address:Port on which Gossip Exchanges will happen
-	GossipListenAddr string `protobuf:"bytes,9,opt,name=gossip_listen_addr,proto3" json:"gossip_listen_addr,omitempty"`
+	GossipListenAddr     string   `protobuf:"bytes,9,opt,name=gossip_listen_addr,proto3" json:"gossip_listen_addr,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/gossip/minimal/configpb/config.pb.go
+++ b/gossip/minimal/configpb/config.pb.go
@@ -236,9 +236,9 @@ type GossipConfig struct {
 	Monitor []*MonitorConfig `protobuf:"bytes,6,rep,name=monitor,json=monitor,proto3" json:"monitor,omitempty"`
 	// GossiperIdentifier is a unique identifier/prefix for a monitor
 	// it is used as a description of gossip origin in exchanged gossip information
-	GossiperIdentifier 	 string		`protobuf:"bytes,7,req,name=gossiper_identifier,proto3" json:"gossiper_identifier,omitempty"`
+	GossiperIdentifier 	 string		`protobuf:"bytes,7,opt,name=gossiper_identifier,proto3" json:"gossiper_identifier,omitempty"`
 	// the RPC endpoint to connect to Trillian
-	RPCEndpoint          string   `protobuf:"bytes,8,req,name=rpc_endpoint,proto3" json:"rpc_endpoint,omitempty"`
+	RPCEndpoint          string   `protobuf:"bytes,8,opt,name=rpc_endpoint,proto3" json:"rpc_endpoint,omitempty"`
 	// The Address:Port on which Gossip Exchanges will happen
 	GossipListenAddr string `protobuf:"bytes,9,opt,name=gossip_listen_addr,proto3" json:"gossip_listen_addr,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/gossip/minimal/configpb/config.proto
+++ b/gossip/minimal/configpb/config.proto
@@ -58,6 +58,16 @@ message HubConfig {
   int64 start_index = 6;
 }
 
+message MonitorConfig {
+  // Human-readable name for the monitor; must be unique
+  string name = 1;
+  // Base URL for the monitor.
+  string url = 2;
+  // Monitor's public key.
+  // todo: This is optional and needs to be incorporated in some way
+  keyspb.PublicKey public_key = 3;
+}
+
 // GossipConfig describes the configuration of a gossiper.
 message GossipConfig {
   // The source logs whose STHs will be logged.
@@ -77,6 +87,15 @@ message GossipConfig {
   google.protobuf.Any private_key = 4;
   // Number of buffered STHs allowed. Must not be negative.
   int32 buffer_size = 5;
+
+  // The monitors with whom we will accept and exchange gossip on source logs
+  repeated MonitorConfig monitor = 6;
+  // a unique name/prefix by which a gossiper will identify itself in gossip broadcasts
+  string GossiperIdentifier = 7
+	// the RPC endpoint to connect to Trillian
+	string RPCEndpoint = 8
+	// The Address:Port on which Gossip Exchanges will happen
+	string GossipListenAddr = 9
 }
 
 // GoshawkConfig describes the configuration of a gossiper.

--- a/gossip/minimal/configpb/config.proto
+++ b/gossip/minimal/configpb/config.proto
@@ -91,11 +91,11 @@ message GossipConfig {
   // The monitors with whom we will accept and exchange gossip on source logs
   repeated MonitorConfig monitor = 6;
   // a unique name/prefix by which a gossiper will identify itself in gossip broadcasts
-  string GossiperIdentifier = 7
+  string GossiperIdentifier = 7;
 	// the RPC endpoint to connect to Trillian
-	string RPCEndpoint = 8
+	string RPCEndpoint = 8;
 	// The Address:Port on which Gossip Exchanges will happen
-	string GossipListenAddr = 9
+	string GossipListenAddr = 9;
 }
 
 // GoshawkConfig describes the configuration of a gossiper.

--- a/gossip/minimal/gossip.go
+++ b/gossip/minimal/gossip.go
@@ -68,8 +68,6 @@ var (
 	writeErrorsCounter monitoring.Counter // hubname => value
 )
 
-const GOSSIP_NOT_ACKNOWLEDGED = ct.GossipExchangeResponse{Acknowledged: false}
-
 // setupMetrics initializes all the exported metrics.
 func setupMetrics(mf monitoring.MetricFactory) {
 	if mf == nil {
@@ -412,7 +410,7 @@ func (g *Gossiper) HandleGossipListener(rw http.ResponseWriter, req *http.Reques
 		}
 		glog.Infof("HandleGossipListener: GossipResponse\n%v\n", gossipResp)
 	} else {
-		gossipResp, _ := gossip.EncodeGossipResponse(rw, GOSSIP_NOT_ACKNOWLEDGED)
+		gossipResp, _ := gossip.EncodeGossipResponse(rw, ct.GossipExchangeResponse{Acknowledged: false})
 		glog.Infof("HandleGossipListener: Ignoring Gossip Information because it is not relevant %v\n", gossipResp)
 	}
 }

--- a/gossip/minimal/gossip.go
+++ b/gossip/minimal/gossip.go
@@ -280,13 +280,13 @@ func (g *Gossiper) Run(ctx context.Context) {
 		g.Listen(ctx)
 		glog.Info("finished Gossip Listener")
 	}()
+	glog.Info("starting Gossip Broadcaster")
+	g.Broadcast(ctx, sths)
+	glog.Info("finished Gossip Broadcaster")
 	///////////////////////////////////
 	// glog.Info("starting Submitter")
 	// g.Submitter(ctx, sths)
 	// glog.Info("finished Submitter")
-	glog.Info("starting Gossip Broadcaster")
-	g.Broadcast(ctx, sths)
-	glog.Info("finished Gossip Broadcaster")
 
 	// Drain the sthInfo channel during shutdown so the Retrievers don't block on it.
 	go func() {
@@ -533,8 +533,8 @@ func (src *sourceLog) GetNewerEntries(ctx context.Context, g *Gossiper, lastSTH,
 	prevTreeSize := lastSTH.TreeSize
 	glog.V(1).Infof("Retriever(%s): Previous Tree Size (%v)", src.Name, prevTreeSize)
 
-	startIndex, endIndex := int64(prevTreeSize+1), int64(prevTreeSize+newTreeSize)
-	glog.V(1).Infof("Get newer entries for source log %s from (%v) to (%v)", src.Name, startIndex, endIndex)
+	startIndex, endIndex := int64(prevTreeSize+1), int64(newTreeSize)
+	glog.Infof("GetNewerEntries(%s) from index (%v) to (%v). Expect %v entries.", src.Name, startIndex, endIndex, endIndex-startIndex+1)
 	entries, err := src.Log.GetEntries(ctx, startIndex, endIndex)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get new entries: %v", err)

--- a/gossip/minimal/gossip.go
+++ b/gossip/minimal/gossip.go
@@ -229,16 +229,16 @@ type monitor struct {
 // distributes it to a destination log in the form of an X.509 certificate with
 // the STH value embedded in it.
 type Gossiper struct {
-	signer           crypto.Signer
-	root             *x509.Certificate
-	dests            map[string]*destHub
-	srcs             map[string]*sourceLog
-	monitors         map[string]*monitor
-	bufferSize       int
+	signer             crypto.Signer
+	root               *x509.Certificate
+	dests              map[string]*destHub
+	srcs               map[string]*sourceLog
+	monitors           map[string]*monitor
+	bufferSize         int
 	gossiperIdentifier string
-	gossipListenAddr string
-	rpcEndpoint      string
-	privateKey       *any.Any
+	gossipListenAddr   string
+	rpcEndpoint        string
+	privateKey         *any.Any
 }
 
 // CheckCanSubmit checks whether the gossiper can submit STHs to all destination hubs.
@@ -299,9 +299,10 @@ func (g *Gossiper) Run(ctx context.Context) {
 }
 
 func (g *Gossiper) getAllSrcLogUrls() []string {
-	urls := make([]string, len(g.srcs))
-	for i, src := range g.srcs {
+	urls, i := make([]string, len(g.srcs)), 0
+	for _, src := range g.srcs {
 		urls[i] = src.URL
+		i++
 	}
 	return urls
 }

--- a/gossip/minimal/instance.go
+++ b/gossip/minimal/instance.go
@@ -41,6 +41,7 @@ const (
 	defaultRateHz       = 1.0
 	defaultMinInterval  = 1 * time.Second
 	overrideNeedPrivKey = true
+	defaultGossipListenAddr	= ":6966"
 )
 
 // NewGossiperFromFile creates a gossiper from the given filename, which should
@@ -92,6 +93,11 @@ func NewBoundaryGossiper(ctx context.Context, cfg *configpb.GossipConfig, hcLog,
 	}
 	if len(cfg.Monitor) == 0 {
 		glog.Warningf("No monitors found; Running in compatibility mode")
+	}
+	if len(cfg.RPCEndpoint) == 0 {
+		glog.Warningf("NOT CONFIGURED --- RPC Endpoint for gossip storage; Gossip will not work without a trillian backend (port:8090)")
+	} else {
+		glog.Infof("configured RPC Endpoint for gossip storage at %+v", cfg.RPCEndpoint)
 	}
 
 	needPrivKey := false
@@ -188,10 +194,11 @@ func NewBoundaryGossiper(ctx context.Context, cfg *configpb.GossipConfig, hcLog,
 		}
 	}
 
-	listenOn := ":6966"
-	if cfg.GossipListenAddr != "" {
+	var listenOn string
+	if listenOn = defaultGossipListenAddr; len(cfg.GossipListenAddr) != 0 {
 		listenOn = cfg.GossipListenAddr
 	}
+	glog.Infof("configured gossip listen addr to %+v", listenOn)
 
 	return &Gossiper{
 		signer:     signer,

--- a/gossip/minimal/instance.go
+++ b/gossip/minimal/instance.go
@@ -38,10 +38,10 @@ import (
 )
 
 const (
-	defaultRateHz       = 1.0
-	defaultMinInterval  = 1 * time.Second
-	overrideNeedPrivKey = true
-	defaultGossipListenAddr	= ":6966"
+	defaultRateHz           = 1.0
+	defaultMinInterval      = 1 * time.Second
+	overrideNeedPrivKey     = true
+	defaultGossipListenAddr = ":6966"
 )
 
 // NewGossiperFromFile creates a gossiper from the given filename, which should

--- a/gossip/minimal/instance.go
+++ b/gossip/minimal/instance.go
@@ -42,6 +42,7 @@ const (
 	defaultMinInterval      = 1 * time.Second
 	overrideNeedPrivKey     = true
 	defaultGossipListenAddr = ":6966"
+	defaultGossiperIdentifier = "defaultGossiperIdentifier"
 )
 
 // NewGossiperFromFile creates a gossiper from the given filename, which should
@@ -99,6 +100,16 @@ func NewBoundaryGossiper(ctx context.Context, cfg *configpb.GossipConfig, hcLog,
 	} else {
 		glog.Infof("configured RPC Endpoint for gossip storage at %+v", cfg.RPCEndpoint)
 	}
+	var listenOn string
+	if listenOn = defaultGossipListenAddr; len(cfg.GossipListenAddr) != 0 {
+		listenOn = cfg.GossipListenAddr
+	}
+	glog.Infof("configured gossip listen addr to %+v", listenOn)
+	var gossiperIdentifier string
+	if gossiperIdentifier = defaultGossiperIdentifier; len(cfg.GossiperIdentifier) != 0 {
+		listenOn = cfg.GossipListenAddr
+	}
+	glog.Infof("configured GossiperIdentifier as %+v", gossiperIdentifier)
 
 	needPrivKey := false
 	for _, destHub := range cfg.DestHub {
@@ -194,11 +205,6 @@ func NewBoundaryGossiper(ctx context.Context, cfg *configpb.GossipConfig, hcLog,
 		}
 	}
 
-	var listenOn string
-	if listenOn = defaultGossipListenAddr; len(cfg.GossipListenAddr) != 0 {
-		listenOn = cfg.GossipListenAddr
-	}
-	glog.Infof("configured gossip listen addr to %+v", listenOn)
 
 	return &Gossiper{
 		signer:     signer,
@@ -208,6 +214,7 @@ func NewBoundaryGossiper(ctx context.Context, cfg *configpb.GossipConfig, hcLog,
 		monitors:   monitors,
 		bufferSize: int(cfg.BufferSize),
 		/// TODO: input sanitization for gossipListenAddr, rpcEndpoint
+		gossiperIdentifier: gossiperIdentifier,
 		gossipListenAddr: listenOn,
 		rpcEndpoint:      cfg.RPCEndpoint,
 		privateKey:       cfg.PrivateKey,

--- a/gossip/minimal/instance.go
+++ b/gossip/minimal/instance.go
@@ -38,10 +38,10 @@ import (
 )
 
 const (
-	defaultRateHz           = 1.0
-	defaultMinInterval      = 1 * time.Second
-	overrideNeedPrivKey     = true
-	defaultGossipListenAddr = ":6966"
+	defaultRateHz             = 1.0
+	defaultMinInterval        = 1 * time.Second
+	overrideNeedPrivKey       = true
+	defaultGossipListenAddr   = ":6966"
 	defaultGossiperIdentifier = "defaultGossiperIdentifier"
 )
 
@@ -214,9 +214,9 @@ func NewBoundaryGossiper(ctx context.Context, cfg *configpb.GossipConfig, hcLog,
 		bufferSize: int(cfg.BufferSize),
 		/// TODO: input sanitization for gossipListenAddr, rpcEndpoint
 		gossiperIdentifier: gossiperIdentifier,
-		gossipListenAddr: listenOn,
-		rpcEndpoint:      cfg.RPCEndpoint,
-		privateKey:       cfg.PrivateKey,
+		gossipListenAddr:   listenOn,
+		rpcEndpoint:        cfg.RPCEndpoint,
+		privateKey:         cfg.PrivateKey,
 	}, nil
 }
 

--- a/trillian/feeder/feeder.go
+++ b/trillian/feeder/feeder.go
@@ -61,7 +61,7 @@ func DialTrillian(ctx context.Context, rpcEndpoint string) (*grpc.ClientConn, er
 
 // InitializeFeeder creates a tree for every source log
 func InitializeFeeder(ctx context.Context, rpcEndpoint string, logUrls []string) *Portal {
-	if len(rpcEndpoint) == 0{
+	if len(rpcEndpoint) == 0 {
 		glog.Exitf("no RPC endpoint specified")
 	}
 	conn, err := DialTrillian(ctx, rpcEndpoint)

--- a/trillian/feeder/feeder.go
+++ b/trillian/feeder/feeder.go
@@ -17,13 +17,14 @@ package feeder
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	ct "github.com/google/certificate-transparency-go"
-	"github.com/google/certificate-transparency-go/trillian/util"
+	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
 	"google.golang.org/grpc"
@@ -34,6 +35,11 @@ import (
 )
 
 const millisPerNano int64 = 1000 * 1000
+const leafIndex = 0
+
+type Dialer interface {
+	DialTrillian(string) (*grpc.ClientConn, error)
+}
 
 // A Portal allows the feeder to connect to trillian and feed data for a log to its tree
 type Portal struct {
@@ -129,19 +135,31 @@ func buildLogLeafForGossiper(gossipReq ct.GossipExchangeRequest, portal *Portal)
 	// Get the current time in the form used throughout RFC6962, namely milliseconds since Unix
 	// epoch, and use this throughout.
 	timeMillis := uint64(time.Now().UnixNano() / millisPerNano)
+	gossipEntryData := []byte(fmt.Sprintf("%v", gossipReq))
 
-	cert := &ct.ASN1Cert{Data: []byte(fmt.Sprintf("%v", gossipReq))}
-	merkleLeaf := ct.MerkleTreeLeaf{
+	leafData, err := tls.Marshal(ct.MerkleTreeLeaf{
 		Version:  ct.V1,
 		LeafType: ct.TimestampedEntryLeafType,
 		TimestampedEntry: &ct.TimestampedEntry{
-			EntryType: ct.X509LogEntryType,
+			EntryType: ct.GossipLogEntryType,
 			Timestamp: timeMillis,
-			X509Entry: cert,
+			GossipEntry: &ct.GossipEntry{
+				Data: gossipEntryData,
+			},
 		},
+	})
+	if err != nil {
+		glog.Warningf("buildLogLeafForGossiper: Failed to serialize Merkle leaf: %v", err)
+		return trillian.LogLeaf{}, err
 	}
-	return util.BuildLogLeaf(portal.RPCEndpoint, merkleLeaf, 0,
-		*cert, []ct.ASN1Cert{}, false)
+
+	leafIDHash := sha256.Sum256(gossipEntryData)
+	return trillian.LogLeaf{
+		LeafValue:        leafData,
+		ExtraData:        nil,
+		LeafIndex:        leafIndex,
+		LeafIdentityHash: leafIDHash[:],
+	}, nil
 }
 
 func newCreateDefaultTreeRequest() *trillian.CreateTreeRequest {

--- a/trillian/feeder/feeder.go
+++ b/trillian/feeder/feeder.go
@@ -35,6 +35,7 @@ import (
 )
 
 const millisPerNano int64 = 1000 * 1000
+const leafIndex = 0
 
 // A Portal allows the feeder to connect to trillian and feed data for a log to its tree
 type Portal struct {

--- a/trillian/feeder/feeder.go
+++ b/trillian/feeder/feeder.go
@@ -35,11 +35,6 @@ import (
 )
 
 const millisPerNano int64 = 1000 * 1000
-const leafIndex = 0
-
-type Dialer interface {
-	DialTrillian(string) (*grpc.ClientConn, error)
-}
 
 // A Portal allows the feeder to connect to trillian and feed data for a log to its tree
 type Portal struct {

--- a/types.go
+++ b/types.go
@@ -38,6 +38,7 @@ type LogEntryType tls.Enum // tls:"maxval:65535"
 const (
 	X509LogEntryType    LogEntryType = 0
 	PrecertLogEntryType LogEntryType = 1
+	GossipLogEntryType  LogEntryType = 2
 	XJSONLogEntryType   LogEntryType = 0x8000 // Experimental.  Don't rely on this!
 )
 
@@ -47,6 +48,8 @@ func (e LogEntryType) String() string {
 		return "X509LogEntryType"
 	case PrecertLogEntryType:
 		return "PrecertLogEntryType"
+	case GossipLogEntryType:
+		return "GossipLogEntryType"
 	case XJSONLogEntryType:
 		return "XJSONLogEntryType"
 	default:
@@ -131,6 +134,11 @@ type LogID struct {
 type PreCert struct {
 	IssuerKeyHash  [sha256.Size]byte
 	TBSCertificate []byte `tls:"minlen:1,maxlen:16777215"` // DER-encoded TBSCertificate
+}
+
+// type GossipEntry represents gossiped information obtained from another monitor
+type GossipEntry struct {
+	Data []byte `tls:"minlen:1,maxlen:16777215"`
 }
 
 // CTExtensions is a representation of the raw bytes of any CtExtension
@@ -363,6 +371,7 @@ type TimestampedEntry struct {
 	EntryType    LogEntryType   `tls:"maxval:65535"`
 	X509Entry    *ASN1Cert      `tls:"selector:EntryType,val:0"`
 	PrecertEntry *PreCert       `tls:"selector:EntryType,val:1"`
+	GossipEntry  *GossipEntry   `tls:"selector:EntryType,val:2"`
 	JSONEntry    *JSONDataEntry `tls:"selector:EntryType,val:32768"`
 	Extensions   CTExtensions   `tls:"minlen:0,maxlen:65535"`
 }
@@ -579,6 +588,7 @@ type GetEntryAndProofResponse struct {
 // via the PostGossipExchange method
 type GossipExchangeRequest struct {
 	LogURL       string           `json:"logUrl"`
+	GossipOrigin string           `json:"gossipOrigin"`
 	STH          SignedTreeHead   `json:"sth"`
 	IsConsistent bool             `json:"isConsistent"`
 	Proof        ConsistencyProof `json:"proof"`

--- a/types.go
+++ b/types.go
@@ -136,7 +136,7 @@ type PreCert struct {
 	TBSCertificate []byte `tls:"minlen:1,maxlen:16777215"` // DER-encoded TBSCertificate
 }
 
-// type GossipEntry represents gossiped information obtained from another monitor
+// GossipEntry represents gossiped information obtained from another monitor
 type GossipEntry struct {
 	Data []byte `tls:"minlen:1,maxlen:16777215"`
 }


### PR DESCRIPTION
* Creates a specific type in Trillian Trees to store gossip information (`GossipLogEntryType` and `GossipEntry`)
* Adds clarity to GossipExchange by adding a configurable `GossipOrigin` identifier, i.e., a name for a gossiper can be specified in the config file
* Filtering gossip information and explicitly not acknowledging it when a gossiper receives information about a log it does not monitor
* Compatibility for parsing config in binary protobuf format (through updates to `config.proto`)

Further considerations:
* Creating specific Acknowledgment states ("Accepted", "NotInteretest", et cetera) instead of just True or False to be specific
* check for `todo:`s